### PR TITLE
Remove JSON serialization from stack.to_json() function

### DIFF
--- a/GDInv_ItemStack.gd
+++ b/GDInv_ItemStack.gd
@@ -36,7 +36,7 @@ func from_json(json_data: Dictionary):
 		stackSize = int(size);
 
 # Returns json string that should be enough to represent this item.
-func to_json() -> String:
+func to_json():
 	var Data: Dictionary = {};
 
 	# Put data into dictionary.
@@ -47,4 +47,4 @@ func to_json() -> String:
 	Data["stackSize"] = stackSize;
 	Data["capabilities"] = capabilities;
 
-	return to_json(Data); # Serialize as json.
+	return Data; # Serialize as json.


### PR DESCRIPTION
Serializing the stack to JSON makes the whole stack a string, and makes an unimportable string. Like this:
```
{"stacks":["{\"capabilities\":{},\"item\":\"wheat_seeds\",\"stackSize\":2}","{\"capabilities\":{},\"item\":\"ground\",\"stackSize\":1}",null,null,null,null,null,null,null,null]}
```
Changing `return to_json(Data)` to `return Data` creates a string like this:
```
{"stacks":[{"capabilities":{},"item":"wheat_seeds","stackSize":2},{"capabilities":{},"item":"ground","stackSize":1},null,null,null,null,null,null,null,null]}
```